### PR TITLE
switch version in manifest.json to use minimum verison number instead…

### DIFF
--- a/custom_components/technitiumdns/manifest.json
+++ b/custom_components/technitiumdns/manifest.json
@@ -10,6 +10,6 @@
   "integration_type": "device",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/Amateur-God/home-assistant-Technitiumdns/issues",
-  "requirements": ["aiohttp==3.10.0"],
+  "requirements": ["aiohttp>=3.9.0"],
   "version": "2.2.1"
 }


### PR DESCRIPTION
[switch version in manifest.json to use minimum verison number instead of set version number](https://github.com/Amateur-God/home-assistant-technitiumdns/commit/e319165d0ced729cbbcb57894de5c12c40917486)

# Proposed Changes

> (Describe the changes and rationale behind them)

Resolves #29 #28 

> ([Github link][autolink-references] to related issues or pull requests)

[autolink-references]: https://help.github.com/articles/autolinked-references-and-urls/
