### PR TITLE
Fix typo in constants

### DIFF
--- a/custom_components/technitiumdns/const.py
+++ b/custom_components/technitiumdns/const.py
@@ -4,7 +4,7 @@ DOMAIN = "technitiumdns"
 
 DURATION_OPTIONS = ["LastHour", "LastDay", "LastWeek", "LastMonth"]
 
-AD_BLOCKING_SWITCH = "Enbable Ad Blocking"
+AD_BLOCKING_SWITCH = "Enable Ad Blocking"
 
 AD_BLOCKING_DURATION_OPTIONS = {
     5: "Disable Ad Blocking for 5 Minutes",


### PR DESCRIPTION
# Proposed Changes

There was a typo in the AD_BLOCKING_SWITCH which meant that the entity was called "Enbable". 
This PR updates the constant value so that it is now "Enable".

## Related Issues

None.